### PR TITLE
[SC-128] lookup portfolio IDs

### DIFF
--- a/config/prod/sc-tag-options.yaml
+++ b/config/prod/sc-tag-options.yaml
@@ -48,5 +48,5 @@ sceptre_user_data:
     - "xindi.guo@sagebase.org"
     - "verena.chung@sagebase.org"
   ProductIDs:
-    - "port-odhghpyclpkuw"   # EC2 RA portfolio
-    - "port-jpwj7fhltwy5m"   # S3 basic portfolio
+    - !stack_output_external sc-portfolio-ec2::SCEC2portfolioId
+    - !stack_output_external sc-portfolio-s3-basic::SCS3portfolio


### PR DESCRIPTION
Instead of hard coded portfolio IDs in our templates we can use
sceptre stack_output_external[1] resolver to lookup the values.

This depends on PRs:
* https://github.com/Sage-Bionetworks/service-catalog-library/pull/126
* https://github.com/Sage-Bionetworks/service-catalog-library/pull/130

[1] https://sceptre.cloudreach.com/2.3.0/docs/resolvers.html#stack-output-external