### PR TITLE
[SC-111] Sceptre deploy Ec2 products

### DIFF
--- a/config/prod/sc-portfolio-ec2.yaml
+++ b/config/prod/sc-portfolio-ec2.yaml
@@ -3,9 +3,6 @@ stack_name: "sc-portfolio-ec2"
 dependencies:
   - "prod/sc-ec2vpc-launchrole.yaml"
   - "prod/sc-enduser-iam.yaml"
-parameters:
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-portfolio-ec2.yaml --create-dirs -o templates/remote/sc-portfolio-ec2.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-notebook.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-ec2-linux-jumpcloud-notebook.yaml"
+stack_name: "sc-product-ec2-linux-jumpcloud-notebook"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-notebook.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-notebook.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud-workflows.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-ec2-linux-jumpcloud-workflows.yaml"
+stack_name: "sc-product-ec2-linux-jumpcloud-workflows"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud-workflows.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud-workflows.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-ec2-jumpcloud.yaml"
+stack_name: "sc-product-ec2-jumpcloud"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-jumpcloud.yaml"

--- a/config/prod/sc-product-ec2-linux-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-linux-jumpcloud.yaml
@@ -1,5 +1,5 @@
-template_path: "remote/sc-product-ec2-jumpcloud.yaml"
-stack_name: "sc-product-ec2-jumpcloud"
+template_path: "remote/sc-product-ec2-linux-jumpcloud.yaml"
+stack_name: "sc-product-ec2-linux-jumpcloud"
 stack_tags:
   Department: "Platform"
   Project: "Infrastructure"
@@ -11,4 +11,4 @@ parameters:
   StackDatetime: !date
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-jumpcloud.yaml"
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-linux-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-linux-jumpcloud.yaml"

--- a/config/prod/sc-product-ec2-windows-jumpcloud.yaml
+++ b/config/prod/sc-product-ec2-windows-jumpcloud.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-ec2-windows-jumpcloud.yaml"
+stack_name: "sc-product-ec2-windows-jumpcloud"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-ec2.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-ec2-windows-jumpcloud.yaml --create-dirs -o templates/remote/sc-product-ec2-windows-jumpcloud.yaml"


### PR DESCRIPTION
Use sceptre to deploy EC2 products and manage dependencies.
This depends on PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/139