### PR TITLE
[SC-111] Sceptre deploy S3 products

### DIFF
--- a/config/prod/sc-portfolio-s3-basic.yaml
+++ b/config/prod/sc-portfolio-s3-basic.yaml
@@ -7,9 +7,6 @@ stack_tags:
 dependencies:
   - "prod/sc-s3-launchrole.yaml"
   - "prod/sc-enduser-iam.yaml"
-parameters:
-  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
-  StackDatetime: !date
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/s3/sc-portfolio-s3-basic.yaml --create-dirs -o templates/remote/sc-portfolio-s3-basic.yaml"

--- a/config/prod/sc-product-s3-private-enc.yaml
+++ b/config/prod/sc-product-s3-private-enc.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-s3-private-enc.yaml"
+stack_name: "sc-product-s3-private-enc"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-s3-basic.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-s3-private-enc.yaml --create-dirs -o templates/remote/sc-product-s3-private-enc.yaml"

--- a/config/prod/sc-product-s3-synapse.yaml
+++ b/config/prod/sc-product-s3-synapse.yaml
@@ -1,0 +1,14 @@
+template_path: "remote/sc-product-s3-synapse.yaml"
+stack_name: "sc-product-s3-synapse"
+stack_tags:
+  Department: "Platform"
+  Project: "Infrastructure"
+  OwnerEmail: "it@sagebase.org"
+dependencies:
+  - "prod/sc-portfolio-s3-basic.yaml"
+parameters:
+  RepoRootURL: "https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/"
+  StackDatetime: !date
+hooks:
+  before_launch:
+    - !cmd "curl https://s3.amazonaws.com/{{stack_group_config.admincentral_cf_bucket}}/{{stack_group_config.service_catalog_library}}/master/ec2/sc-product-s3-synapse.yaml --create-dirs -o templates/remote/sc-product-s3-synapse.yaml"


### PR DESCRIPTION
Use sceptre to deploy S3 products and manage dependencies.
This depends on PR https://github.com/Sage-Bionetworks/service-catalog-library/pull/141